### PR TITLE
frontend setup fixed

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,8 +79,9 @@ Encore
     ;
 
 
-module.exports = Encore.getWebpackConfig();
+// module.exports = Encore.getWebpackConfig();
 
 const config = Encore.getWebpackConfig();
 config.resolve.conditionNames = ['browser', 'svelte', 'import'];
 
+module.exports = config;


### PR DESCRIPTION
Here is a pull request to fix your frontend setup. Here is what I have done:

- commented out ``module.exports = Encore.getWebpackConfig();`` in ``webpack.config.js``
- appended ``module.exports = config;`` to ``webpack.config.js``
- added path ``assets/controllers/`` as ``StimulusBundle`` is requiring it

I hope this will help you :)